### PR TITLE
Use GITHUB_ENV and G_ACCOUNT in remaining containerfiles and workflows

### DIFF
--- a/.github/workflows/premerge_amazonlinux2.yml
+++ b/.github/workflows/premerge_amazonlinux2.yml
@@ -35,43 +35,22 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - uses: actions/checkout@v2
-    - name: Extract branch from PR
+    - name: Extract environment variables from PR
       shell: bash
       run: |
-        echo "##[set-output name=branch;]${GITHUB_HEAD_REF}"
-        echo "##[set-output name=owner;]${GITHUB_REPOSITORY_OWNER}"
-      id: pr_branch
-    #- name: Testing guild-deploy.sh (system libsodium)
-    #  run: |
-    #    export BRANCH=${{ steps.pr_branch.outputs.branch }}
-    #    export G_ACCOUNT=${{ steps.pr_branch.outputs.owner }}
-    #    export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-    #    docker build . --file files/tests/pre-merge/amazonlinux2-guild-deploy.sh.containerfile --compress --build-arg BRANCH --build-arg COMMIT --build-arg G_ACCOUNT --tag ghcr.io/cardano-community/pre-merge-amazonlinux2:guild-deploy_${COMMIT}
-    #- name: Push pre-merge-amazonlinux2:guild-deploy_${COMMIT}
-    #  run: |
-    #    export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-    #    docker push ghcr.io/cardano-community/pre-merge-amazonlinux2:guild-deploy_${COMMIT}
-    #- name: Testing cabal-build-all.sh (system libsodium)
-    #  run: |
-    #    export BRANCH=${{ steps.pr_branch.outputs.branch }}
-    #    export G_ACCOUNT=${{ steps.pr_branch.outputs.owner }}
-    #    export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-    #    echo "Working from PR Branch ${G_ACCOUNT}/guild-operators/${BRANCH} on Commit ${COMMIT}"
-    #    docker build . --file files/tests/pre-merge/amazonlinux2-cabal.containerfile --compress --build-arg BRANCH --build-arg COMMIT --tag ghcr.io/cardano-community/pre-merge-amazonlinux2:cabal_${COMMIT}
+        echo "G_ACCOUNT=${GITHUB_REPOSITORY_OWNER}" >> $GITHUB_ENV
+        echo "BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+        echo "COMMIT=$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
+    - name: Workflow Summary
+      shell: bash
+      run: |
+        echo "Premerge testing ${G_ACCOUNT}/guild-operators/${BRANCH} for commit ${COMMIT}"
     - name: Testing guild-deploy.sh (IO fork of libsodium)
       run: |
-        export BRANCH=${{ steps.pr_branch.outputs.branch }}
-        export G_ACCOUNT=${{ steps.pr_branch.outputs.owner }}
-        export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-        docker build . --file files/tests/pre-merge/amazonlinux2-guild-deploy.sh-l.containerfile --compress --build-arg BRANCH --build-arg COMMIT --build-arg G_ACCOUNT --tag ghcr.io/cardano-community/pre-merge-amazonlinux2:guild-deploy-l_${COMMIT}
+        docker build . --file files/tests/pre-merge/amazonlinux2-guild-deploy.sh-l.containerfile --compress --build-arg BRANCH --build-arg COMMIT --build-arg G_ACCOUNT --tag ghcr.io/${G_ACCOUNT}/pre-merge-amazonlinux2:guild-deploy-l_${COMMIT}
     - name: Push pre-merge-amazonlinux2:guild-deploy_${COMMIT}
       run: |
-        export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-        docker push ghcr.io/cardano-community/pre-merge-amazonlinux2:guild-deploy-l_${COMMIT}
+        docker push ghcr.io/${G_ACCOUNT}/pre-merge-amazonlinux2:guild-deploy-l_${COMMIT}
     - name: Testing cabal-build-all.sh (IO fork of libsodium)
       run: |
-        export BRANCH=${{ steps.pr_branch.outputs.branch }}
-        export G_ACCOUNT=${{ steps.pr_branch.outputs.owner }}
-        export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-        echo "Working from PR Branch ${G_ACCOUNT}/guild-operators/${BRANCH} on Commit ${COMMIT}"
-        docker build . --file files/tests/pre-merge/amazonlinux2-cabal.containerfile --compress --build-arg BRANCH --build-arg COMMIT --tag ghcr.io/cardano-community/pre-merge-amazonlinux2:cabal-l_${COMMIT}
+        docker build . --file files/tests/pre-merge/amazonlinux2-cabal.containerfile --compress --build-arg BRANCH --build-arg COMMIT --tag ghcr.io/${G_ACCOUNT}/pre-merge-amazonlinux2:cabal-l_${COMMIT}

--- a/.github/workflows/premerge_debian.yml
+++ b/.github/workflows/premerge_debian.yml
@@ -35,44 +35,23 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - uses: actions/checkout@v2
-    - name: Extract branch from PR
+    - name: Extract environment variables from PR
       shell: bash
       run: |
-        echo "##[set-output name=branch;]${GITHUB_HEAD_REF}"
-        echo "##[set-output name=owner;]${GITHUB_REPOSITORY_OWNER}"
-      id: pr_branch
-    #- name: Testing guild-deploy.sh (system libsodium)
-    #  run: |
-    #    export BRANCH=${{ steps.pr_branch.outputs.branch }}
-    #    export G_ACCOUNT=${{ steps.pr_branch.outputs.owner }}
-    #    export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-    #    docker build . --file files/tests/pre-merge/debian-guild-deploy.sh.containerfile --compress --build-arg BRANCH --build-arg COMMIT --build-arg G_ACCOUNT --tag ghcr.io/cardano-community/pre-merge-debian:guild-deploy_${COMMIT}
-    #- name: Push pre-merge-debian:guild-deploy_${COMMIT}
-    #  run: |
-    #    export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-    #    docker push ghcr.io/cardano-community/pre-merge-debian:guild-deploy_${COMMIT}
-    #- name: Testing cabal-build-all.sh (system libsodium)
-    #  run: |
-    #    export BRANCH=${{ steps.pr_branch.outputs.branch }}
-    #    export G_ACCOUNT=${{ steps.pr_branch.outputs.owner }}
-    #    export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-    #    echo "Working from PR Branch ${G_ACCOUNT}/guild-operators/${BRANCH} on Commit ${COMMIT}"
-    #    docker build . --file files/tests/pre-merge/debian-cabal.containerfile --compress --build-arg BRANCH --build-arg COMMIT --tag ghcr.io/cardano-community/pre-merge-debian:cabal_${COMMIT}
+        echo "G_ACCOUNT=${GITHUB_REPOSITORY_OWNER}" >> $GITHUB_ENV
+        echo "BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+        echo "COMMIT=$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
+    - name: Workflow Summary
+      shell: bash
+      run: |
+        echo "Premerge testing ${G_ACCOUNT}/guild-operators/${BRANCH} for commit ${COMMIT}"
     - name: Testing guild-deploy.sh (IO fork of libsodium)
       run: |
-        export BRANCH=${{ steps.pr_branch.outputs.branch }}
-        export G_ACCOUNT=${{ steps.pr_branch.outputs.owner }}
-        export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-        docker build . --file files/tests/pre-merge/debian-guild-deploy.sh-l.containerfile --compress --build-arg BRANCH --build-arg COMMIT --build-arg G_ACCOUNT --tag ghcr.io/cardano-community/pre-merge-debian:guild-deploy-l_${COMMIT}
+        docker build . --file files/tests/pre-merge/debian-guild-deploy.sh-l.containerfile --compress --build-arg BRANCH --build-arg COMMIT --build-arg G_ACCOUNT --tag ghcr.io/${G_ACCOUNT}/pre-merge-debian:guild-deploy-l_${COMMIT}
     - name: Push pre-merge-debian:guild-deploy-l_${COMMIT}
       run: |
-        export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-        docker push ghcr.io/cardano-community/pre-merge-debian:guild-deploy-l_${COMMIT}
+        docker push ghcr.io/${G_ACCOUNT}/pre-merge-debian:guild-deploy-l_${COMMIT}
     - name: Testing cabal-build-all.sh (IO fork of libsodium)
       run: |
-        export BRANCH=${{ steps.pr_branch.outputs.branch }}
-        export G_ACCOUNT=${{ steps.pr_branch.outputs.owner }}
-        export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-        echo "Working from PR Branch ${G_ACCOUNT}/guild-operators/${BRANCH} on Commit ${COMMIT}"
         docker build . --file files/tests/pre-merge/debian-cabal-l.containerfile --compress --build-arg BRANCH --build-arg COMMIT --tag ghcr.io/cardano-community/pre-merge-debian:cabal-l_${COMMIT}
 

--- a/.github/workflows/premerge_rockylinux.yml
+++ b/.github/workflows/premerge_rockylinux.yml
@@ -35,43 +35,22 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - uses: actions/checkout@v2
-    - name: Extract branch from PR
+    - name: Extract environment variables from PR
       shell: bash
       run: |
-        echo "##[set-output name=branch;]${GITHUB_HEAD_REF}"
-        echo "##[set-output name=owner;]${GITHUB_REPOSITORY_OWNER}"
-      id: pr_branch
-    #- name: Testing guild-deploy.sh (system libsodium)
-    #  run: |
-    #    export BRANCH=${{ steps.pr_branch.outputs.branch }}
-    #    export G_ACCOUNT=${{ steps.pr_branch.outputs.owner }}
-    #    export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-    #    docker build . --file files/tests/pre-merge/rockylinux-guild-deploy.sh.containerfile --compress --build-arg BRANCH --build-arg COMMIT --build-arg G_ACCOUNT --tag ghcr.io/cardano-community/pre-merge-rockylinux:guild-deploy_${COMMIT}
-    #- name: Push pre-merge-rockylinux:guild-deploy_${COMMIT}
-    #  run: |
-    #    export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-    #    docker push ghcr.io/cardano-community/pre-merge-rockylinux:guild-deploy_${COMMIT}
-    #- name: Testing cabal-build-all.sh (system libsodium)
-    #  run: |
-    #    export BRANCH=${{ steps.pr_branch.outputs.branch }}
-    #    export G_ACCOUNT=${{ steps.pr_branch.outputs.owner }}
-    #    export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-    #    echo "Working from PR Branch ${G_ACCOUNT}/guild-operators/${BRANCH} on Commit ${COMMIT}"
-    #    docker build . --file files/tests/pre-merge/rockylinux-cabal.containerfile --compress --build-arg BRANCH --build-arg COMMIT --tag ghcr.io/cardano-community/pre-merge-rockylinux:cabal_${COMMIT}
+        echo "G_ACCOUNT=${GITHUB_REPOSITORY_OWNER}" >> $GITHUB_ENV
+        echo "BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+        echo "COMMIT=$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
+    - name: Workflow Summary
+      shell: bash
+      run: |
+        echo "Premerge testing ${G_ACCOUNT}/guild-operators/${BRANCH} for commit ${COMMIT}"
     - name: Testing guild-deploy.sh (IO fork of libsodium)
       run: |
-        export BRANCH=${{ steps.pr_branch.outputs.branch }}
-        export G_ACCOUNT=${{ steps.pr_branch.outputs.owner }}
-        export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-        docker build . --file files/tests/pre-merge/rockylinux-guild-deploy.sh-l.containerfile --compress --build-arg BRANCH --build-arg COMMIT --build-arg G_ACCOUNT --tag ghcr.io/cardano-community/pre-merge-rockylinux:guild-deploy-l_${COMMIT}
+        docker build . --file files/tests/pre-merge/rockylinux-guild-deploy.sh-l.containerfile --compress --build-arg BRANCH --build-arg COMMIT --build-arg G_ACCOUNT --tag ghcr.io/${G_ACCOUNT}/pre-merge-rockylinux:guild-deploy-l_${COMMIT}
     - name: Push pre-merge-rockylinux:guild-deploy-l_${COMMIT}
       run: |
-        export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-        docker push ghcr.io/cardano-community/pre-merge-rockylinux:guild-deploy-l_${COMMIT}
+        docker push ghcr.io/${G_ACCOUNT}/pre-merge-rockylinux:guild-deploy-l_${COMMIT}
     - name: Testing cabal-build-all.sh (IO fork of libsodium)
       run: |
-        export BRANCH=${{ steps.pr_branch.outputs.branch }}
-        export G_ACCOUNT=${{ steps.pr_branch.outputs.owner }}
-        export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-        echo "Working from PR Branch ${G_ACCOUNT}/guild-operators/${BRANCH} on Commit ${COMMIT}"
-        docker build . --file files/tests/pre-merge/rockylinux-cabal-l.containerfile --compress --build-arg BRANCH --build-arg COMMIT --tag ghcr.io/cardano-community/pre-merge-rockylinux:cabal-l_${COMMIT}
+        docker build . --file files/tests/pre-merge/rockylinux-cabal-l.containerfile --compress --build-arg BRANCH --build-arg COMMIT --tag ghcr.io/${G_ACCOUNT}/pre-merge-rockylinux:cabal-l_${COMMIT}

--- a/.github/workflows/premerge_ubuntu.yml
+++ b/.github/workflows/premerge_ubuntu.yml
@@ -35,43 +35,30 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - uses: actions/checkout@v2
-    - name: Extract branch from PR
+    - name: Extract environment variables from PR
       shell: bash
       run: |
-        echo "##[set-output name=branch;]${GITHUB_HEAD_REF}"
-        echo "##[set-output name=owner;]${GITHUB_REPOSITORY_OWNER}"
-      id: pr_branch
-    #- name: Testing guild-deploy.sh (system libsodium)
-    #  run: |
-    #    export BRANCH=${{ steps.pr_branch.outputs.branch }}
-    #    export G_ACCOUNT=${{ steps.pr_branch.outputs.owner }}
-    #    export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-    #    docker build . --file files/tests/pre-merge/ubuntu-guild-deploy.sh.containerfile --compress --build-arg BRANCH --build-arg COMMIT --build-arg G_ACCOUNT --tag ghcr.io/cardano-community/pre-merge-ubuntu:guild-deploy_${COMMIT}
-    #- name: Push pre-merge-ubuntu:guild-deploy_${COMMIT}
-    #  run: |
-    #    export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-    #    docker push ghcr.io/cardano-community/pre-merge-ubuntu:guild-deploy_${COMMIT}
-    #- name: Testing cabal-build-all.sh (system libsodium)
-    #  run: |
-    #    export BRANCH=${{ steps.pr_branch.outputs.branch }}
-    #    export G_ACCOUNT=${{ steps.pr_branch.outputs.owner }}
-    #    export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-    #    echo "Working from PR Branch ${G_ACCOUNT}/guild-operators/${BRANCH} on Commit ${COMMIT}"
-    #    docker build . --file files/tests/pre-merge/ubuntu-cabal.containerfile --compress --build-arg BRANCH --build-arg COMMIT --tag ghcr.io/cardano-community/pre-merge-ubuntu:cabal_${COMMIT}
+        echo "G_ACCOUNT=${GITHUB_REPOSITORY_OWNER}" >> $GITHUB_ENV
+        echo "BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+        echo "COMMIT=$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
+    - name: Workflow Summary
+      shell: bash
+      run: |
+        echo "Premerge testing ${G_ACCOUNT}/guild-operators/${BRANCH} for commit ${COMMIT}"
     - name: Testing guild-deploy.sh (IO fork of libsodium)
       run: |
         export BRANCH=${{ steps.pr_branch.outputs.branch }}
         export G_ACCOUNT=${{ steps.pr_branch.outputs.owner }}
         export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-        docker build . --file files/tests/pre-merge/ubuntu-guild-deploy.sh-l.containerfile --compress --build-arg BRANCH --build-arg COMMIT --build-arg G_ACCOUNT --tag ghcr.io/cardano-community/pre-merge-ubuntu:guild-deploy-l_${COMMIT}
+        docker build . --file files/tests/pre-merge/ubuntu-guild-deploy.sh-l.containerfile --compress --build-arg BRANCH --build-arg COMMIT --build-arg G_ACCOUNT --tag ghcr.io/${G_ACCOUNT}/pre-merge-ubuntu:guild-deploy-l_${COMMIT}
     - name: Push pre-merge-ubuntu:guild-deploy-l_${COMMIT}
       run: |
         export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-        docker push ghcr.io/cardano-community/pre-merge-ubuntu:guild-deploy-l_${COMMIT}
+        docker push ghcr.io/${G_ACCOUNT}/pre-merge-ubuntu:guild-deploy-l_${COMMIT}
     - name: Testing cabal-build-all.sh (IO fork of libsodium)
       run: |
         export BRANCH=${{ steps.pr_branch.outputs.branch }}
         export G_ACCOUNT=${{ steps.pr_branch.outputs.owner }}
         export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
         echo "Working from PR Branch ${G_ACCOUNT}/guild-operators/${BRANCH} on Commit ${COMMIT}"
-        docker build . --file files/tests/pre-merge/ubuntu-cabal-l.containerfile --compress --build-arg BRANCH --build-arg COMMIT --tag ghcr.io/cardano-community/pre-merge-ubuntu:cabal-l_${COMMIT}
+        docker build . --file files/tests/pre-merge/ubuntu-cabal-l.containerfile --compress --build-arg BRANCH --build-arg COMMIT --tag ghcr.io/${G_ACCOUNT}/pre-merge-ubuntu:cabal-l_${COMMIT}

--- a/files/tests/pre-merge/amazonlinux2-cabal-l.containerfile
+++ b/files/tests/pre-merge/amazonlinux2-cabal-l.containerfile
@@ -1,6 +1,6 @@
 ARG COMMIT
-FROM ghcr.io/cardano-community/pre-merge-amazonlinux2:guild-deploy-l_${COMMIT}
 ARG G_ACCOUNT
+FROM ghcr.io/${G_ACCOUNT}/pre-merge-amazonlinux2:guild-deploy-l_${COMMIT}
 ARG BRANCH
 ARG CNODE_HOME=/opt/cardano/cnode
 

--- a/files/tests/pre-merge/debian-cabal-l.containerfile
+++ b/files/tests/pre-merge/debian-cabal-l.containerfile
@@ -1,6 +1,6 @@
 ARG COMMIT
-FROM ghcr.io/cardano-community/pre-merge-debian:guild-deploy-l_${COMMIT}
 ARG G_ACCOUNT
+FROM ghcr.io/${G_ACCOUNT}/pre-merge-debian:guild-deploy-l_${COMMIT}
 ARG BRANCH
 ARG CNODE_HOME=/opt/cardano/cnode
 

--- a/files/tests/pre-merge/rockylinux-cabal-l.containerfile
+++ b/files/tests/pre-merge/rockylinux-cabal-l.containerfile
@@ -1,6 +1,6 @@
 ARG COMMIT
-FROM ghcr.io/cardano-community/pre-merge-rockylinux:guild-deploy-l_${COMMIT}
 ARG G_ACCOUNT
+FROM ghcr.io/${G_ACCOUNT}/pre-merge-rockylinux:guild-deploy-l_${COMMIT}
 ARG BRANCH
 ARG CNODE_HOME=/opt/cardano/cnode
 

--- a/files/tests/pre-merge/ubuntu-cabal-l.containerfile
+++ b/files/tests/pre-merge/ubuntu-cabal-l.containerfile
@@ -1,6 +1,6 @@
 ARG COMMIT
-FROM ghcr.io/cardano-community/pre-merge-ubuntu:guild-deploy-l_${COMMIT}
 ARG G_ACCOUNT
+FROM ghcr.io/${G_ACCOUNT}/pre-merge-ubuntu:guild-deploy-l_${COMMIT}
 ARG BRANCH
 ARG CNODE_HOME=/opt/cardano/cnode
 


### PR DESCRIPTION
Apply the same G_ACCOUNT logic to the remaining premerge workflows. 