### PR TITLE
Update topology.json

### DIFF
--- a/files/configs/preview/topology.json
+++ b/files/configs/preview/topology.json
@@ -12,7 +12,8 @@
   "publicRoots": [
     {
       "accessPoints": [
-        {"address": "preview-node.play.dev.cardano.org", "port": 3001}
+        {"address": "preview-node.play.dev.cardano.org", "port": 3001},
+        {"address": "preview-node-test-change.play.dev.cardano.org", "port": 9999}
       ],
       "advertise": false
     }


### PR DESCRIPTION
Change to test issue 1750 since configs for master and alpha are currently identical, should see preview-node-test-change.play.dev.cardano.org appear in topology.json when the container is created/run with `-e G_ACCOUNT=TrevorBenson -e UPDATE_CHECK=Y`

